### PR TITLE
fix: Set Node.js project type to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "express": "^5.1.0",
     "openai": "^5.16.0"


### PR DESCRIPTION
The application was failing to start on Render due to a `SyntaxError: Cannot use import statement outside a module`.

This occurs because the `server.js` file uses ES module `import` syntax, but the `package.json` had `"type": "commonjs"`, which is the default.

This commit changes the type to `"module"` in `package.json` to correctly inform Node.js to treat .js files as ES modules, resolving the startup error.