### PR TITLE
fix(frontend): Add missing HTML elements for report download

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -479,6 +479,10 @@
             <button type="submit">Soumettre pour analyse</button>
         </form>
 
+        <div id="report-download-area" class="hidden">
+            <a href="#" id="download-report-link" download="rapport-conformite.txt" class="button-secondary">Télécharger le rapport de vos réponses</a>
+        </div>
+
         <section id="analysis-section" class="hidden">
             <h2>Analyse de la conformité</h2>
             <div id="analysis-result">


### PR DESCRIPTION
Fixes JavaScript errors caused by missing HTML elements.

The script was trying to access elements with IDs 'report-download-area' and 'download-report-link' which did not exist in index.html, causing null reference exceptions.

This change adds the required div and anchor elements to the HTML, resolving the errors and enabling the report download feature.